### PR TITLE
fix: security vulnerability CVE-2018-3721

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "mocha": "^2.2.5"
   },
   "dependencies": {
-    "lodash": "^3.9.3",
+    "lodash": "^4.17.11",
     "request": "^2.58.0"
   }
 }


### PR DESCRIPTION
CVE-2018-3721 
Vulnerable versions: <4.17.5
Patched version: 4.17.5
lodash node module before 4.17.5 suffers from a Modification of Assumed-Immutable Data (MAID) vulnerability via defaultsDeep, merge, and mergeWith functions, which allows a malicious user to modify the prototype of "Object" via proto, causing the addition or modification of an existing property that will exist on all objects.